### PR TITLE
Add FABulous board and open_eFPGA_v2 to the profile page

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -9,13 +9,13 @@ Group of Dirk Koch and his great students and postdocs.
 - [FABulous](https://github.com/FPGA-Research/FABulous) - FPGA Fabric generator
 - [FABulator](https://github.com/FPGA-Research/FABulator) - Graphical frontend for FABulous
 
-### Bitstream Analyzation and Manipulation
+### Bitstream Analysis and Manipulation
 - [GoAhead](https://github.com/FPGA-Research/GoAhead)
 - [byteman](https://github.com/FPGA-Research/byteman)
 
 ### Security
 - [FPGA-VS-Web](https://github.com/FPGA-Research/FPGA-VS-Web) - FPGA Virus Scanner Web Application
-- [FPGA Virus scanner](https://github.com/FPGA-Research/FPGAVirusScanne) -  Program to scan for malicious FPGA designs
+- [FPGA Virus scanner](https://github.com/FPGA-Research/FPGAVirusScanne) - Program to scan for malicious FPGA designs
 
 ### Database Accelerator
 - [OrkhestraFPGAStream](https://github.com/FPGA-Research/OrkhestraFPGAStream)
@@ -28,12 +28,14 @@ Group of Dirk Koch and his great students and postdocs.
 - [FuseRISC](https://github.com/FPGA-Research/fuserisc)
 - [eFPGA](https://github.com/FPGA-Research/eFPGA---RTL-to-GDS-with-SKY130) - RTL-to-GDS with SKY130
 - [FABulous-SKY130](https://github.com/FPGA-Research/FABulous-SKY130)
+- [open_eFPGA_v2](https://github.com/FPGA-Research/open_eFPGA_v2)
+- [FABulous_board](https://github.com/FPGA-Research/FABulous_board) -A PCB created for FABulous FPGAs, based on the caravel board.
 
 ### Other Projects
-- [XilinxTCL_utilities](https://github.com/FPGA-Research/XilinxTCL_utilities) - A collection of tcl script for Xilinx FPGAs
+- [XilinxTCL_utilities](https://github.com/FPGA-Research/XilinxTCL_utilities) - A collection of tcl scripts for Xilinx FPGAs
 - [zynq-ultrascale-readback-capture](https://github.com/FPGA-Research/zynq-ultrascale-readback-capture) - How to do readback capture on the Zynq UltraScale
 - [readdebugbitstream](https://github.com/FPGA-Research/readdebugbitstream)
 
 ### Related External Projects and Contributions
-- [Yosys](https://github.com/YosysHQ/yosys) -  Yosys Open SYnthesis Suite
+- [Yosys](https://github.com/YosysHQ/yosys) - Yosys Open SYnthesis Suite
 - [nextpnr](https://github.com/YosysHQ/nextpnr) - A portable FPGA place and route tool


### PR DESCRIPTION
This adds the FABulous board and the open_eFPGA_v2 to the profile page . Also small typos were fixed.